### PR TITLE
Fixed empty IP address when en1 is not the default interface

### DIFF
--- a/bin/archey
+++ b/bin/archey
@@ -16,7 +16,12 @@ versionMajor=`echo $versionNumber | cut -d'.' -f1`
 versionMinor=`echo $versionNumber | cut -d'.' -f2`
 versionShort="${versionMajor}.${versionMinor}"
 
+
+## en1 or en0 should contain the ip address
 ipAddress=`ipconfig getifaddr en1`
+if [ -z "$ipAddress" ]; then
+    ipAddress=`ipconfig getifaddr en0`
+fi
 
 case $versionShort in
     10.10)


### PR DESCRIPTION
Sometimes instead of `en1`, `en0` is the currently active interface.
This fix checks if `en1` has an IP address and, if this is not the case, reads the IP address from `en0` instead.
