### PR TITLE
Set colors back to normal after executing script.

### DIFF
--- a/bin/archey
+++ b/bin/archey
@@ -114,3 +114,4 @@ ${BLUE}        ################              Disk Used: $disk
 ${BLUE}         ####     #####               Internal IP: $ipAddress
 
 "
+tput sgr0


### PR DESCRIPTION
The colors are stuck as the color of the last output line unless you specify to put them back to normal.
