### PR TITLE
Fixed Homebrew parameter to be passed for brew list

### DIFF
--- a/bin/archey
+++ b/bin/archey
@@ -90,7 +90,7 @@ shell="$SHELL"
 terminal="$TERM"
 
 ## Number of packages installed via Homebrew
-packages="`brew list -l | wc -l | awk '{print $1 }'`"
+packages="`brew list -l --formula| wc -l | awk '{print $1 }'`"
 
 ## CPU Type
 cpu=$(sysctl -n machdep.cpu.brand_string)


### PR DESCRIPTION
I have updated the brew command parameter list by passing --formula, which is now mandatory for 'brew list'